### PR TITLE
Add topics attribute and validate the manifests for topics.

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -128,20 +128,31 @@ actual domain."
       handler = ManifestHandler.new @@settings
       handler.read_remote
       count_ok = 0
+      count_warning = 0
       handler.libraries.each do |library|
         library.manifests.each do |manifest|
           result = v.verify manifest
           result.print_result
-          if result.valid?
+          if result.valid? && result.safe?
             count_ok += 1
-          else
+          elsif !result.valid?
             errors.push result
+          end
+          if !result.safe?
+            count_warning +=1
           end
         end
       end
       puts
-      puts "#{handler.manifests.count} manifests checked. #{count_ok} ok, " +
-        "#{errors.count} with error."
+      if(count_warning == 1)
+        puts "#{handler.manifests.count} manifests checked. #{count_ok} ok, " +
+          "#{errors.count} with error, " +
+          "#{count_warning} warning."
+      else
+        puts "#{handler.manifests.count} manifests checked. #{count_ok} ok, " +
+          "#{errors.count} with error, " +
+          "#{count_warning} warnings."
+      end
       if !errors.empty?
         puts
         puts "Errors:"

--- a/lib/manifest.rb
+++ b/lib/manifest.rb
@@ -38,6 +38,7 @@ class Manifest < JsonObject
   attribute :release_date
   attribute :version
   attribute :summary
+  attribute :topics
   attribute :urls do
     attribute :homepage
     attribute :api_docs

--- a/lib/verifier.rb
+++ b/lib/verifier.rb
@@ -17,15 +17,21 @@
 class Verifier
 
   class Result
-    attr_accessor :errors, :name
+    attr_accessor :errors, :warnings, :name
     
     def initialize
       @valid = false
+      @safe = false
       @errors = Array.new
+      @warnings = Array.new
     end
     
     def valid?
       @errors.empty?
+    end
+
+    def safe?
+      @warnings.empty?
     end
 
     def print_result
@@ -36,6 +42,11 @@ class Verifier
         puts "error"
         @errors.each do |error|
           puts "  #{error}"
+        end
+      end
+      if !safe?
+        @warnings.each do |warning|
+          puts "  #{warning}"
         end
       end
     end
@@ -75,6 +86,11 @@ class Verifier
       errors = JSON::Validator.fully_validate(schema_file, manifest.to_json)
       errors.each do |error|
         @result.errors.push "Schema validation error: #{error}"
+      end
+
+      topics =  manifest.topics
+      if topics.nil?
+        @result.warnings.push "Warning: missing `topics` attribute"
       end
     end
 

--- a/schema/generic-manifest-v1
+++ b/schema/generic-manifest-v1
@@ -10,6 +10,13 @@
     "summary": {
       "type": "string"
     },
+    "topics": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "minItems": 1
+    },
     "urls": {
       "type": "object",
       "properties": {

--- a/schema/proprietary-release-manifest-v1
+++ b/schema/proprietary-release-manifest-v1
@@ -16,6 +16,13 @@
     "summary": {
       "type": "string"
     },
+    "topics": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "minItems": 1
+    },
     "urls": {
       "type": "object",
       "properties": {

--- a/schema/release-manifest-v1
+++ b/schema/release-manifest-v1
@@ -16,6 +16,13 @@
     "summary": {
       "type": "string"
     },
+    "topics": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "minItems": 1
+    },
     "urls": {
       "type": "object",
       "properties": {

--- a/spec/data/inqlude-all.json
+++ b/spec/data/inqlude-all.json
@@ -5,6 +5,9 @@
     "release_date": "2013-09-08",
     "version": "0.2.0",
     "summary": "Awesome library",
+    "topics": [
+      "API"
+    ],
     "urls": {
       "homepage": "http://example.com",
       "download": "http://example.com/download"
@@ -76,6 +79,9 @@
     "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
     "name": "newlib",
     "summary": "A new lib under heavy development",
+    "topics": [
+      "Bindings"
+    ],
     "urls": {
       "homepage": "http://new.example.org",
       "download": "http://new.example.org/download"

--- a/spec/data/manifests/awesomelib/awesomelib.2013-09-08.manifest
+++ b/spec/data/manifests/awesomelib/awesomelib.2013-09-08.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-09-08",
   "version": "0.2.0",
   "summary": "Awesome library",
+  "topics": [
+    "API"
+  ],
   "urls": {
     "homepage": "http://example.com",
     "download": "http://example.com/download"

--- a/spec/data/manifests/newlib/newlib.manifest
+++ b/spec/data/manifests/newlib/newlib.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "newlib",
   "summary": "A new lib under heavy development",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://new.example.org",
     "download": "http://new.example.org/download"

--- a/spec/data/missing-topics/missing-topics.manifest
+++ b/spec/data/missing-topics/missing-topics.manifest
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
+  "name": "missing-topics",
+  "summary": "No topics",
+  "urls": {
+    "homepage": "http://topics.org",
+    "download": "http://topics.org/download"
+  },
+  "licenses": [
+    "GPLv3"
+  ],
+  "description": "This is a library with no topics.",
+  "authors": [
+    "Cornelius Schumacher <schumacher@kde.org>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows"
+  ]
+}

--- a/spec/integration/cli_verify_spec.rb
+++ b/spec/integration/cli_verify_spec.rb
@@ -29,7 +29,7 @@ describe "Command line interface" do
 Verify manifest awesomelib.2013-09-08.manifest...ok
 Verify manifest newlib.manifest...ok
 
-2 manifests checked. 2 ok, 0 with error.
+2 manifests checked. 2 ok, 0 with error, 0 warnings.
 EOT
       expect(result).to exit_with_success(expected_output)
     end
@@ -63,8 +63,9 @@ Verify manifest broken.manifest...error
   Schema validation error: The property '#/' did not contain a required property of 'licenses' in schema http://inqlude.org/schema/generic-manifest-v1#
   Schema validation error: The property '#/' did not contain a required property of 'description' in schema http://inqlude.org/schema/generic-manifest-v1#
   Schema validation error: The property '#/' did not contain a required property of 'platforms' in schema http://inqlude.org/schema/generic-manifest-v1#
+  Warning: missing `topics` attribute
 
-2 manifests checked. 1 ok, 1 with error.
+2 manifests checked. 1 ok, 1 with error, 1 warning.
 
 Errors:
   broken.manifest
@@ -77,6 +78,23 @@ Errors:
     Schema validation error: The property '#/' did not contain a required property of 'platforms' in schema http://inqlude.org/schema/generic-manifest-v1#
 EOT
       expect(result).to exit_with_error(1,"",expected_output)
+    end
+
+    it "verifies manifests with topics warning" do
+      dir = given_directory do
+        given_directory_from_data("awesomelib", from: "manifests/awesomelib")
+        given_directory_from_data("missing-topics", from: "missing-topics")
+      end
+
+      result = run_command(args: ["verify", "--offline", "--manifest_dir=#{dir}"])
+      expected_output = <<EOT
+Verify manifest awesomelib.2013-09-08.manifest...ok
+Verify manifest missing-topics.manifest...ok
+  Warning: missing `topics` attribute
+
+2 manifests checked. 1 ok, 0 with error, 1 warning.
+EOT
+      expect(result).to exit_with_success(expected_output)
     end
   end
 end

--- a/spec/unit/verifier_spec.rb
+++ b/spec/unit/verifier_spec.rb
@@ -75,6 +75,24 @@ EOT
         }.to output(expected_output).to_stdout
       end
     end
+
+    context "missing topics" do
+      before do
+        subject.name = "xyz"
+        subject.warnings.push("Warning : missing topics")
+      end
+
+      it "verifies manifests with topics warning" do
+        expected_output = <<EOT
+Verify manifest xyz...ok
+  Warning : missing topics
+EOT
+
+        expect {
+          subject.print_result
+        }.to output(expected_output).to_stdout
+      end
+    end
   end
 
   it "verifies read manifests" do


### PR DESCRIPTION
* Add topics attribute to the Manifest class and manifest specification.
* Allow topic attribute as an optional parameter.
* Display missing topics as a warning in the print_result.
* Modify the output of command line verify command.
* Modify integration tests to account warning messages.
* Add missing-topics.manifest.
* Add unit tests and integration tests to verify manifests with topics warning.

Closes: #33