### PR TITLE
Add topics attribute and validate the manifests for topics

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -128,6 +128,7 @@ actual domain."
       handler = ManifestHandler.new @@settings
       handler.read_remote
       count_ok = 0
+      count_warning = 0
       handler.libraries.each do |library|
         library.manifests.each do |manifest|
           result = v.verify manifest
@@ -137,11 +138,15 @@ actual domain."
           else
             errors.push result
           end
+          if !result.has_warnings?
+            count_warning +=1
+          end
         end
       end
       puts
       puts "#{handler.manifests.count} manifests checked. #{count_ok} ok, " +
-        "#{errors.count} with error."
+        "#{errors.count} with error, " +
+        "#{count_warning} #{count_warning == 1 ? "has warning." : "have warnings."}"
       if !errors.empty?
         puts
         puts "Errors:"

--- a/lib/manifest.rb
+++ b/lib/manifest.rb
@@ -38,6 +38,7 @@ class Manifest < JsonObject
   attribute :release_date
   attribute :version
   attribute :summary
+  attribute :topics
   attribute :urls do
     attribute :homepage
     attribute :api_docs

--- a/lib/verifier.rb
+++ b/lib/verifier.rb
@@ -17,15 +17,21 @@
 class Verifier
 
   class Result
-    attr_accessor :errors, :name
+    attr_accessor :errors, :warnings, :name
     
     def initialize
       @valid = false
+      @safe = false
       @errors = Array.new
+      @warnings = Array.new
     end
     
     def valid?
       @errors.empty?
+    end
+
+    def has_warnings?
+      @warnings.empty?
     end
 
     def print_result
@@ -36,6 +42,11 @@ class Verifier
         puts "error"
         @errors.each do |error|
           puts "  #{error}"
+        end
+      end
+      if !has_warnings?
+        @warnings.each do |warning|
+          puts "  #{warning}"
         end
       end
     end
@@ -75,6 +86,11 @@ class Verifier
       errors = JSON::Validator.fully_validate(schema_file, manifest.to_json)
       errors.each do |error|
         @result.errors.push "Schema validation error: #{error}"
+      end
+
+      topics =  manifest.topics
+      if topics.nil?
+        @result.warnings.push "Warning: missing `topics` attribute"
       end
     end
 

--- a/schema/generic-manifest-v1
+++ b/schema/generic-manifest-v1
@@ -10,6 +10,13 @@
     "summary": {
       "type": "string"
     },
+    "topics": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "minItems": 1
+    },
     "urls": {
       "type": "object",
       "properties": {

--- a/schema/proprietary-release-manifest-v1
+++ b/schema/proprietary-release-manifest-v1
@@ -16,6 +16,13 @@
     "summary": {
       "type": "string"
     },
+    "topics": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "minItems": 1
+    },
     "urls": {
       "type": "object",
       "properties": {

--- a/schema/release-manifest-v1
+++ b/schema/release-manifest-v1
@@ -16,6 +16,13 @@
     "summary": {
       "type": "string"
     },
+    "topics": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "minItems": 1
+    },
     "urls": {
       "type": "object",
       "properties": {

--- a/spec/data/inqlude-all.json
+++ b/spec/data/inqlude-all.json
@@ -5,6 +5,9 @@
     "release_date": "2013-09-08",
     "version": "0.2.0",
     "summary": "Awesome library",
+    "topics": [
+      "API"
+    ],
     "urls": {
       "homepage": "http://example.com",
       "download": "http://example.com/download"
@@ -76,6 +79,9 @@
     "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
     "name": "newlib",
     "summary": "A new lib under heavy development",
+    "topics": [
+      "Bindings"
+    ],
     "urls": {
       "homepage": "http://new.example.org",
       "download": "http://new.example.org/download"

--- a/spec/data/manifests/awesomelib/awesomelib.2013-09-08.manifest
+++ b/spec/data/manifests/awesomelib/awesomelib.2013-09-08.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-09-08",
   "version": "0.2.0",
   "summary": "Awesome library",
+  "topics": [
+    "API"
+  ],
   "urls": {
     "homepage": "http://example.com",
     "download": "http://example.com/download"

--- a/spec/data/manifests/newlib/newlib.manifest
+++ b/spec/data/manifests/newlib/newlib.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "newlib",
   "summary": "A new lib under heavy development",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://new.example.org",
     "download": "http://new.example.org/download"

--- a/spec/data/missing-topics/miss-topics/miss-topics.manifest
+++ b/spec/data/missing-topics/miss-topics/miss-topics.manifest
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
+  "name": "miss-topics",  
+  "summary": "Missing topics",
+  "urls": {
+    "homepage": "http://missing-topics.org",
+    "download": "http://missing-topics.org/download"
+  },
+  "licenses": [
+    "GPLv3"
+  ],
+  "description": "This is a library with topics missing.",
+  "authors": [
+    "Cornelius Schumacher <schumacher@kde.org>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows"
+  ]
+}

--- a/spec/data/missing-topics/no-topics/no-topics.manifest
+++ b/spec/data/missing-topics/no-topics/no-topics.manifest
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
+  "name": "no-topics",
+  "summary": "No topics",
+  "urls": {
+    "homepage": "http://no-topics.org",
+    "download": "http://no-topics.org/download"
+  },
+  "licenses": [
+    "GPLv3"
+  ],
+  "description": "This is a library with no topics.",
+  "authors": [
+    "Cornelius Schumacher <schumacher@kde.org>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows"
+  ]
+}

--- a/spec/integration/cli_verify_spec.rb
+++ b/spec/integration/cli_verify_spec.rb
@@ -29,7 +29,7 @@ describe "Command line interface" do
 Verify manifest awesomelib.2013-09-08.manifest...ok
 Verify manifest newlib.manifest...ok
 
-2 manifests checked. 2 ok, 0 with error.
+2 manifests checked. 2 ok, 0 with error, 0 have warnings.
 EOT
       expect(result).to exit_with_success(expected_output)
     end
@@ -63,8 +63,9 @@ Verify manifest broken.manifest...error
   Schema validation error: The property '#/' did not contain a required property of 'licenses' in schema http://inqlude.org/schema/generic-manifest-v1#
   Schema validation error: The property '#/' did not contain a required property of 'description' in schema http://inqlude.org/schema/generic-manifest-v1#
   Schema validation error: The property '#/' did not contain a required property of 'platforms' in schema http://inqlude.org/schema/generic-manifest-v1#
+  Warning: missing `topics` attribute
 
-2 manifests checked. 1 ok, 1 with error.
+2 manifests checked. 1 ok, 1 with error, 1 has warning.
 
 Errors:
   broken.manifest
@@ -78,5 +79,41 @@ Errors:
 EOT
       expect(result).to exit_with_error(1,"",expected_output)
     end
+
+    it "verifies manifests with one warning" do
+      dir = given_directory do
+        given_directory_from_data("awesomelib", from: "manifests/awesomelib")
+        given_directory_from_data("miss-topics", from: "missing-topics/miss-topics")
+      end
+
+      result = run_command(args: ["verify", "--offline", "--manifest_dir=#{dir}"])
+      expected_output = <<EOT
+Verify manifest awesomelib.2013-09-08.manifest...ok
+Verify manifest miss-topics.manifest...ok
+  Warning: missing `topics` attribute
+
+2 manifests checked. 2 ok, 0 with error, 1 has warning.
+EOT
+      expect(result).to exit_with_success(expected_output)
+    end
+
+    it "verifies manifests with multiple warnings" do
+      dir = given_directory do
+        given_directory_from_data("miss-topics", from: "missing-topics/miss-topics")
+        given_directory_from_data("no-topics", from: "missing-topics/no-topics")
+      end
+
+      result = run_command(args: ["verify", "--offline", "--manifest_dir=#{dir}"])
+      expected_output = <<EOT
+Verify manifest miss-topics.manifest...ok
+  Warning: missing `topics` attribute
+Verify manifest no-topics.manifest...ok
+  Warning: missing `topics` attribute
+
+2 manifests checked. 2 ok, 0 with error, 2 have warnings.
+EOT
+      expect(result).to exit_with_success(expected_output)
+    end
+
   end
 end

--- a/spec/unit/verifier_spec.rb
+++ b/spec/unit/verifier_spec.rb
@@ -75,6 +75,44 @@ EOT
         }.to output(expected_output).to_stdout
       end
     end
+
+    context "one warning" do
+      before do
+        subject.name = "xyz"
+        subject.warnings.push("a warning")
+      end
+
+      it "prints warning" do
+        expected_output = <<EOT
+Verify manifest xyz...ok
+  a warning
+EOT
+
+        expect {
+          subject.print_result
+        }.to output(expected_output).to_stdout
+      end
+    end
+
+    context "multiple warnings" do
+      before do
+        subject.name = "xyz"
+        subject.warnings.push("a warning")
+        subject.warnings.push("another warning")
+      end
+
+      it "prints warning" do
+        expected_output = <<EOT
+Verify manifest xyz...ok
+  a warning
+  another warning
+EOT
+
+        expect {
+          subject.print_result
+        }.to output(expected_output).to_stdout
+      end
+    end
   end
 
   it "verifies read manifests" do


### PR DESCRIPTION
Add topic attribute to manifest specification and adapt validator to allow topic attribute as an optional parameter. The validator reports missing topics as a warning for each manifest which does not have a topic attribute, but not fail. 

As a result, libraries can be categorized under multiple topics.

Supersedes #33, #34