### PR TITLE
Add list of allowed topics to the validator

### DIFF
--- a/lib/verifier.rb
+++ b/lib/verifier.rb
@@ -91,6 +91,12 @@ class Verifier
       topics =  manifest.topics
       if topics.nil?
         @result.warnings.push "Warning: missing `topics` attribute"
+      else
+        valid_topics = ["API", "Artwork", "Bindings", "Communication", "Data", "Desktop", "Development", "Graphics", 
+          "Logging", "Mobile", "Multimedia", "Printing", "QML", "Scripting", "Security", "Text", "Web", "Widgets"]
+        if !(topics - valid_topics).empty?
+          @result.errors.push "Invalid topics"
+        end
       end
     end
 

--- a/spec/data/invalid-topics/invalid-topics.manifest
+++ b/spec/data/invalid-topics/invalid-topics.manifest
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
+  "name": "invalid-topics",  
+  "summary": "Invalid topics",
+  "topics": [
+    "Invalid"
+  ],
+  "urls": {
+    "homepage": "http://invalid-topics.org",
+    "download": "http://invalid-topics.org/download"
+  },
+  "licenses": [
+    "GPLv3"
+  ],
+  "description": "This is a library with invalid topics.",
+  "authors": [
+    "Cornelius Schumacher <schumacher@kde.org>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows"
+  ]
+}

--- a/spec/integration/cli_verify_spec.rb
+++ b/spec/integration/cli_verify_spec.rb
@@ -115,5 +115,26 @@ EOT
       expect(result).to exit_with_success(expected_output)
     end
 
+    it "verifies all manifests with invalid topics error" do
+      dir = given_directory do
+        given_directory_from_data("awesomelib", from: "manifests/awesomelib")
+        given_directory_from_data("invalid-topics", from: "invalid-topics")
+      end
+
+      result = run_command(args: ["verify", "--offline", "--manifest_dir=#{dir}"])
+      expected_output = <<EOT
+Verify manifest awesomelib.2013-09-08.manifest...ok
+Verify manifest invalid-topics.manifest...error
+  Invalid topics
+
+2 manifests checked. 1 ok, 1 with error, 0 have warnings.
+
+Errors:
+  invalid-topics.manifest
+    Invalid topics
+EOT
+      expect(result).to exit_with_error(1,"",expected_output)
+    end
+
   end
 end

--- a/spec/unit/verifier_spec.rb
+++ b/spec/unit/verifier_spec.rb
@@ -167,6 +167,22 @@ EOT
     expect(result.errors.first).to eq "Expected file name: awesomelib.2013-09-08.manifest"
   end
 
+  it "detects invalid topics" do
+    handler = ManifestHandler.new settings
+    handler.read_remote
+    verifier = Verifier.new settings
+
+    manifest = handler.manifest("awesomelib")
+    expect(verifier.verify(manifest).valid?).to be true
+
+    manifest.topics = ["Invalid"]
+
+    result = verifier.verify(manifest)
+
+    expect(result.valid?).to be false
+    expect(result.errors).to include "Invalid topics"
+  end
+
   it "verifies release manifest file" do
     filename = File.join settings.manifest_path, awesomelib_manifest_file
 


### PR DESCRIPTION
The validator reports an error for each manifest with invalid topics attribute.
As a result, the list of topics is kept small and typographical errors are prevented.