### PR TITLE
Adapt rendering of the library pages to include topics

### DIFF
--- a/view/library.html.haml
+++ b/view/library.html.haml
@@ -4,6 +4,7 @@
 %p
   = m.summary
 
+= list_attribute "topics"
 - if m.has_version?
   = list_attribute_content "Version", version_content
 = list_attribute "licenses"


### PR DESCRIPTION
Modify the library details page to display the topics that the library belongs to.
As a result, user can easily find if the library matches the requirements.