### PR TITLE
Adapt rendering of the library pages to include topics

### DIFF
--- a/view/library.html.haml
+++ b/view/library.html.haml
@@ -10,7 +10,7 @@
 = list_attribute "platforms"
 = list_attribute "authors"
 = list_attribute_content "Home page", link( m.urls.homepage )
-
+= list_attribute "topics"
 = render_description
 
 - if more_urls?


### PR DESCRIPTION
Modify the library details page to display the topics that the library belongs to.
As a result, user can easily find if the library matches the requirements.

Supersedes: #43