### PR TITLE
Add tooling to update manifests with topics

### DIFF
--- a/topics/Manifest_updater/README.md
+++ b/topics/Manifest_updater/README.md
@@ -1,0 +1,19 @@
+**This directory contains a node.js program to update the manifests with topics from 
+the file `topics.csv`.** 
+
+Follow the instructions given below to run the program.
+
+* Install node.js and npm.
+* Copy the library folders that contain the manifest files required to be updated 
+and paste them at `manifests` directory and `update_manifests` directory. 
+* Run `npm install` from this directory.
+* Then run `node app.js` from this directory.
+* You will find the updated manifests at `update_manifests` directory.
+
+
+**Note:**
+* You should have the `topics.csv` file in the same directory that contains `app.js`.
+* Having the manifest files at `manifests` directory is adequate, but make sure that 
+you have the same library folder structure at both `manifests` directory and 
+`update_manifests` directory.
+* Also make sure that you have the details for the required update activity at `topics.csv`.

--- a/topics/Manifest_updater/app.js
+++ b/topics/Manifest_updater/app.js
@@ -1,0 +1,43 @@
+var fs = require('fs');
+var recursive = require('recursive-readdir');
+
+var parse = require('csv-parse');
+var csvAr;
+
+var parser = parse({delimiter: ','}, function(err, data){
+    csvAr = data;
+});
+
+fs.createReadStream(__dirname+'/topics.csv').pipe(parser);
+
+recursive('manifests', function (err, files) {
+  for (var i = files.length - 1; i >= 0; i--) {
+    var fi = files[i];
+    var data = fs.readFileSync(fi, 'utf8');
+    var manifest = JSON.parse(data);
+    var name = manifest.name;
+    var sel = csvAr.filter(function(d) {
+         return d[0] == name;
+    })[0];
+
+    if(!sel){
+      console.log(fi);
+    }
+    var sel1 = sel;
+    
+    sel1 = sel.slice(1);
+    for (var j = 0; j < sel1.length ; j++) {
+       if(sel1[j] === ''){
+         sel1 = sel1.slice(0,j);
+         break;
+       }
+    }
+    
+    manifest.topics = sel1;
+    var data1 = JSON.stringify(manifest, null, 2) + '\n';
+    
+    var fi2 = 'update_'+ fi;
+    fs.writeFileSync(fi2, data1);
+  }
+});
+

--- a/topics/Manifest_updater/manifests/example/example.manifest
+++ b/topics/Manifest_updater/manifests/example/example.manifest
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
+  "name": "example",
+  "summary": "An example library",  
+  "urls": {
+    "homepage": "http://example.org",
+    "download": "http://example.org/download"
+  },
+  "licenses": [
+    "GPLv3"
+  ],
+  "description": "This is an example library",
+  "authors": [
+    "Nanduni Nimalsiri <nandunibw@gmail.com>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows"
+  ]
+}

--- a/topics/Manifest_updater/package.json
+++ b/topics/Manifest_updater/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "Nanduni",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "csv-parse": "^1.1.3",
+    "recursive-readdir": "^2.0.0"
+  }
+}

--- a/topics/Manifest_updater/topics.csv
+++ b/topics/Manifest_updater/topics.csv
@@ -1,0 +1,1 @@
+example,API,QML,

--- a/topics/Manifest_updater/update_manifests/example/example.manifest
+++ b/topics/Manifest_updater/update_manifests/example/example.manifest
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
+  "name": "example",
+  "summary": "An example library",
+  "urls": {
+    "homepage": "http://example.org",
+    "download": "http://example.org/download"
+  },
+  "licenses": [
+    "GPLv3"
+  ],
+  "description": "This is an example library",
+  "authors": [
+    "Nanduni Nimalsiri <nandunibw@gmail.com>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows"
+  ],
+  "topics": [
+    "API",
+    "QML"
+  ]
+}


### PR DESCRIPTION
Add a node.js program to update manifest files automatically with topics specified at `topics.csv` file.

Supersedes: #42, #44