### PR TITLE
Add integration tests for inqlude-all.json

### DIFF
--- a/spec/integration/cli_view_spec.rb
+++ b/spec/integration/cli_view_spec.rb
@@ -24,5 +24,37 @@ describe "Command line interface" do
       expect(File.exist?(File.join(output_dir, "libraries", "awesomelib.html"))).to be(true)
       expect(File.exist?(File.join(output_dir, "libraries", "newlib.html"))).to be(true)
     end
+
+    context "inqlude-all.json" do
+      it "generates view" do
+        output_dir = given_directory
+        result = run_command(args: ["view", "--output-dir=#{output_dir}"])
+
+        expect(File.exist?(File.join(output_dir, "inqlude-all.json"))).to be(true)
+      end
+
+      it "checks format" do
+        output_dir = given_directory
+        result = run_command(args: ["view", "--output-dir=#{output_dir}"])
+        data = File.read(File.join(output_dir, 'inqlude-all.json'))
+
+        expect {
+          parsedData = JSON.parse(data);
+        }.to_not raise_error
+      end
+
+      it "checks number of manifests" do
+        output_dir = given_directory
+        result = run_command(args: ["view", "--output-dir=#{output_dir}"])
+        data = File.read(File.join(output_dir, 'inqlude-all.json'))
+        parsedData = JSON.parse(data);
+
+        settings = Settings.new
+        handler = ManifestHandler.new settings
+        handler.read_remote
+
+        expect(handler.libraries.length).to eq parsedData.length
+      end
+    end
   end
 end

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -1,2 +1,5 @@
 require "cli_tester"
 require "given_filesystem/spec_helpers"
+require "json"
+
+require_relative "../../lib/inqlude"


### PR DESCRIPTION
* Pull the actual data from inqlude-data without the `--offline` option.
* Check if the format of the file is correct.
* Check if the file contains the right number of manifests.