### PR TITLE
Initial prototype for the new layout of the website

### DIFF
--- a/lib/manifest_handler.rb
+++ b/lib/manifest_handler.rb
@@ -53,6 +53,11 @@ class ManifestHandler
       manifest.licenses.include? "Commercial"
     end
   end
+
+  #To populate the `Latest releases` box for the moment
+  def latest_libraries
+    return [library("cutereport"), library("injeqt"), library("marble"), library("qdecimal"), library("qtilities")]
+  end
   
   def group name
     return @libraries.select do |l|

--- a/lib/view.rb
+++ b/lib/view.rb
@@ -112,6 +112,10 @@ class View
     "<a href=\"#{@root}libraries/#{name}.html\">#{name}</a>"
   end
 
+  def link_to_library name, display_name
+    "<a href=\"#{@root}libraries/#{name}.html\">#{display_name}</a>"
+  end
+
   def link url
     "<a href=\"#{url}\" target=\"_blank\">#{url}</a>"
   end
@@ -213,6 +217,10 @@ class View
     @manifest_handler.commercial_libraries
   end
 
+  def latest_libraries
+    @manifest_handler.latest_libraries
+  end
+
   def group_title
     if @group_name == "kde-frameworks"
       return "KDE Frameworks"
@@ -255,6 +263,18 @@ class View
   def render_description
     doc = Kramdown::Document.new(@manifest.description)
     doc.to_html
+  end
+
+  def topics
+    ['API', 'Artwork', 'Bindings', 'Communication', 'Data', 'Desktop', 'Development', 'Graphics', 'Logging', 'Mobile', 'Multimedia', 'Printing', 'QML', 'Scripting', 'Security', 'Text', 'Web', 'Widgets']
+  end
+
+  def platforms
+    ['Android','iOS','Linux','OS x','Windows']
+  end
+
+  def licenses
+    ['Apache','BSD','Commercial','GPL','LGPL','MIT','Qwt']
   end
 
   private

--- a/view/two-column/about.html.haml
+++ b/view/two-column/about.html.haml
@@ -1,0 +1,37 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4 About Inqlude
+
+  %hr
+
+  %p
+    The goal of Inqlude is to provide a comprehensive listing of all
+    existing libraries for developers of Qt applications. If you are creating
+    applications using the Qt toolkit, and are looking for libraries, components
+    or modules to use, Inqlude is the place where you find all information and
+    pointers to get started.
+  %p
+    Inqlude comes with a command line client for handling libraries. See the
+    = link_to "instructions how to get libraries", "get"
+    for more details.
+  %p
+    Inqlude aims to be a complete archive of all available Qt based
+    libraries. If you notice that there is some information missing, outdated
+    or inaccurate, please consider contributing the missing data. See the
+    = link_to "instructions how to contribute", "contribute"
+    for more details.
+  %p
+    %em
+      Note that Inqlude is currently in alpha state. It's not ready for full
+      production use yet. Data is still incomplete, and the tools are
+      limited. Feedback and input is appreciated.
+  %p
+    If you have questions of comments please feel free to write to the Inqlude
+    mailing list #{link_to "inqlude@kde.org", "mailto:inqlude@kde.org"}.
+  %p
+    Inqlude was created by
+    = link_to "Cornelius Schumacher", "mailto:schumacher@kde.org"
+    with the help of many others, and is a proud  member of the KDE family.
+  %br

--- a/view/two-column/contribute.html.haml
+++ b/view/two-column/contribute.html.haml
@@ -1,0 +1,58 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4 Contributing data about libraries
+
+  %hr
+
+  %p
+    To get a complete overview about all available Qt based libraries, we need
+    to collect data about these libraries. This includes descriptions,
+    instructions how to use them, as well as links to sources or installable
+    packages.
+  %p
+    The meta data used by Inqlude is collected in a git repository at
+    = link( "http://github.com/cornelius/inqlude-data" )
+    or
+    = link( "https://projects.kde.org/projects/websites/inqlude-data" ) + "."
+    It contains a manifest file in JSON format for each library, which has the
+    meta data in a structured machine-readable form. JSON is easy enough for
+    humans to read and edit as well. See the
+    = link_to "specification of the manifest format", "https://github.com/cornelius/inqlude/blob/master/manifest-format.md"
+    for documentation about what to put into the manifest.
+  %p
+    You can contribute meta data by providing patches to the inqlude-data
+    repository. Use the github mechanisms or just send patches by email.
+    Contributions are welcome.
+
+  %br
+
+  %h4 Contributing to the Inqlude tools
+
+  %hr
+
+  %p
+    The command line tool is developed in another git repository at
+    = link( "http://github.com/cornelius/inqlude" )
+    or
+    = link( "https://projects.kde.org/projects/websites/inqlude" ) + "."
+    It's still in a proof-of-concept state, so there is quite a bit work left.
+    Have a look at the
+    = link_to "list of open issues", "http://github.com/cornelius/inqlude/issues"
+    or read the source and come up with your own ideas what to improve.
+  %p
+    Especially welcome are contributions for adding support for native
+    package systems on the variety of Linux distributions and other systems
+    out there.
+    
+  %br
+
+  %h4 Mailing list
+
+  %hr
+
+  %p
+    If you want to discuss any aspects of Inqlude, get in contact with us, have
+    questions, or want to contribute in any other way, the best way is to use the
+    mailing list #{link_to "inqlude@kde.org", "https://mail.kde.org/mailman/listinfo/inqlude"}.

--- a/view/two-column/get.html.haml
+++ b/view/two-column/get.html.haml
@@ -1,0 +1,61 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4
+    How to get libraries
+
+  %hr
+
+  %p
+    This page is about how to use Inqlude as a user, a developer using Qt
+    based libraries in her projects.
+  %p
+    First you can just use the web site. Find the information about libraries
+    here, and get the libraries using the provided links. This works and is the
+    recommended way for now, but there is an experimental, but more convenient
+    way.
+  %p
+    You can also use the command line client. This client makes it easy to get
+    the libraries you need with just a few commands, without having to know
+    URLs, or how libraries are packages.
+  %p
+    First you need to get the command line client.
+    It's a Qt 5 application. If your distribution doesn't have a package for
+    inqlude-client, you can download its sources from
+    = link_to( "download.kde.org", "http://download.kde.org/devel/helpers/")
+    or using
+    .code
+      git clone git://anongit.kde.org/inqlude-client
+  %p
+    There is a second command line client, written in Ruby. It can also
+    download libraries, but it is mostly aimed at maintaining the inqlude data.
+    It's available as a Ruby gem, so when you have rubygems installed you can simply do a
+    .code
+      sudo gem install inqlude
+    (For instructions how to get rubygems, see
+    = link_to( "rubygems.org", "http://rubygems.org" ) + ")."
+  %p
+    Once you have the client, you can get help about the available commands
+    with
+    .code
+      inqlude
+    Get a list of available libraries with
+    .code
+      inqlude list -r
+
+    Install a library with 
+    .code
+      inqlude install &lt;library_name&gt;
+
+    Get a list of installed libraries with
+    .code
+      inqlude list
+  %p
+    The command line client uses your native package management system. In
+    case there is no meta data available for your system, the client falls
+    back to handling sources. Please consider helping to get your system
+    supported by contributing meta data or implementing a backend for your
+    system. See the
+    = link_to "instructions how to contribute", "contribute"
+    for more details.

--- a/view/two-column/home.html.haml
+++ b/view/two-column/home.html.haml
@@ -1,2 +1,0 @@
-%p
-  This is home page.

--- a/view/two-column/index.html.haml
+++ b/view/two-column/index.html.haml
@@ -1,0 +1,180 @@
+%h4
+  Stable libraries
+
+%table.table-hover
+  - libraries(:stable).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple
+      %td.topics
+        - library.manifests.last.topics.each do |topic|
+          - if (topic != library.manifests.last.topics.last)
+            = topic + ", "
+          - else 
+            = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+%br  
+
+%h4
+  Developer releases
+
+%table.table-hover
+  - libraries(:beta).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple         
+      %td.topics
+        - library.manifests.last.topics.each do |topic|
+          - if (topic != library.manifests.last.topics.last)
+            = topic + ", "
+          - else 
+            = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+  - libraries(:alpha).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple         
+      %td.topics
+        - library.manifests.last.topics.each do |topic|
+          - if (topic != library.manifests.last.topics.last)
+            = topic + ", "
+          - else 
+            = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+  - libraries(:edge).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple         
+      %td.topics
+        - library.manifests.last.topics.each do |topic|
+          - if (topic != library.manifests.last.topics.last)
+            = topic + ", "
+          - else 
+            = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+%br    
+
+%h4
+  Unreleased libraries
+
+%table.table-hover
+  - unreleased_libraries.each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple
+      %td.topics
+        - library.manifests.last.topics.each do |topic|
+          - if (topic != library.manifests.last.topics.last)
+            = topic + ", "
+          - else 
+            = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+%br
+
+%hr
+
+%span.footer
+  Last updated on #{Date.today}
+  

--- a/view/two-column/layout.html.haml
+++ b/view/two-column/layout.html.haml
@@ -5,49 +5,101 @@
   - if enable_search
     <link href='https://fonts.googleapis.com/css?family=Droid+Sans' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://www.google.com/cse/style/look/default.css" type="text/css" />
-%body
-  .ribbon
-    = link_to "Alpha", "about"
+  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" type="text/css" href="public/inqlude.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+  <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
-  .container
-    .header
-      .logo
-        %h1
-          %span.logo><
-            \#in
-          %span.logo.green><
-            q
-          %span.logo><
-            lude
-        %h2
-          %span.subtitle
-            The Qt library archive
-      .menu
+%body
+
+  .container-fluid.header
+
+    .col-md-8.logo    
+      %h1
+        %span.logo><
+          \#in
+        %span.logo.green><
+          q
+        %span.logo><
+          lude
+      %h2
+        %span.subtitle
+          The Qt library archive
+
+    .col-md-4.search  
+      - if enable_search
+        %gcse:searchbox-only{ resultsUrl: "https://inqlude.org/search.html" }
+          Loading...
+    %br{ :clear => "all" }
+
+  .container-fluid.content
+
+    .col-sm-3.side-bar
+
+      .col-sm-12.description
+        %p
+          Inqlude provides a comprehensive listing of all existing libraries for developers of applications using the Qt toolkit. Inqlude is run by the community and open for contributions. 
+      
         %ul
           %li
-            = link_to "Home", "index"
+            = link_to "About", "about"
           %li
             = link_to "How to get libraries", "get"
           %li
-            = link_to "How to contribute", "contribute"
-          %li
-            = link_to "About", "about"
-        .search
-          - if enable_search
-            %gcse:searchbox-only{ resultsUrl: "https://inqlude.org/search.html" }
-              Loading...
-      %br{ :clear => "all" }
+            = link_to "How to contribute", "contribute"          
+          
+      .col-sm-12.title 
+        Latest releases   
+      .col-sm-12.latest-releases 
+        %table
+          %tr
+            %td
+              - latest_libraries.each do |library|
+                - if library.latest_manifest.display_name
+                  = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+                - else
+                  = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+                %date
+                  = '(' + library.latest_manifest.release_date + ')'
+                %br                
+        
+      .col-sm-12.title
+        Filters
+      .col-sm-12.filters
+        .col-sm-7.filter-topics
+          %h6
+            Topics
+          - topics.each do |topic|
+            %input{:type=>"checkbox", :name=>"#{topic}"}
+            = topic            
+            %br     
 
-    .content
+        .col-sm-5.filter-platforms
+          %h6
+            Platforms
+          - platforms.each do |platform|
+            %input{:type=>"checkbox", :name=>"#{platform}"}
+            = platform
+            %br     
+        
+        .col-sm-5.filter-licenses
+          %h6
+            Licenses
+          - licenses.each do |license|
+            %input{:type=>"checkbox", :name=>"#{license}"}
+            = license
+            %br     
+
+    .col-sm-9.main-pane 
       = yank
 
       %br{ :clear => "all" }
 
-  .legal
-    Inqlude is a
-    = link_to "KDE project", "http://kde.org"
-    = "|"
-    = link_to "Legal", "http://www.kde.org/community/whatiskde/impressum.php"
+      .legal
+        Inqlude is a
+        = link_to "KDE project", "http://kde.org"
+        = "|"
+        = link_to "Legal", "http://www.kde.org/community/whatiskde/impressum.php"
 
   - if enable_search
     :javascript

--- a/view/two-column/library.html.haml
+++ b/view/two-column/library.html.haml
@@ -1,54 +1,74 @@
-%h2
-  = m.name
+<link rel="stylesheet" type="text/css" href="../public/inqlude.css">
 
-%p
-  = m.summary
+%home
+  = link_to "Home", "index"
 
-- if m.has_version?
-  = list_attribute_content "Version", version_content
-= list_attribute "licenses"
-= list_attribute "platforms"
-= list_attribute "authors"
-= list_attribute_content "Home page", link( m.urls.homepage )
-= list_attribute "topics"
-= render_description
+.col-sm-12.inner-box
+  %h4
+    -if m.display_name
+      = m.display_name
+    -else 
+      = m.name
 
-- if more_urls?
-  %h3 Read more
-  %ul
-    = link_item "api_docs", "API documentation"
-    = link_item "tutorial", "Tutorial"
-    = link_item "download", "Download sources"
-    = link_item "vcs", "Source code repository"
-    = link_item "announcement", "Announcement"
-    = custom_urls
-
-- if m.packages.source
-  %h3 Packages
-  %ul
-    %li
-      = link_to "Source code", m.packages.source
-
-%p{:class => "edit-link"}
-  = link_to "[Edit]", editor_url
-
-%br{:clear => "all"}
-
-- if disqus_enabled?
   %hr
 
-  #disqus_thread
+  .col-sm-12.topics-bar
+    - if m.topics
+      - m.topics.each do |topic|
+        %p{:class => "labels"}
+          = topic
+  
+  %p
+    = m.summary
 
-  :javascript
-    var disqus_config = function () {
-        this.page.url = 'http://inqlude.org/libraries/#{m.name}.html';
-        this.page.identifier = '#{m.name}';
-    };
-    (function() {
-        var d = document, s = d.createElement('script');
+  - if m.has_version?
+    = list_attribute_content "Version", version_content
+  = list_attribute "licenses"
+  = list_attribute "platforms"
+  = list_attribute "authors"
+  = list_attribute_content "Home page", link( m.urls.homepage )
+  = render_description
 
-        s.src = 'https://inqlude.disqus.com/embed.js';
+  %br
 
-        s.setAttribute('data-timestamp', +new Date());
-        (d.head || d.body).appendChild(s);
-    })();
+  - if more_urls?
+    %h4 Read more
+    %ul
+      = link_item "api_docs", "API documentation"
+      = link_item "tutorial", "Tutorial"
+      = link_item "download", "Download sources"
+      = link_item "vcs", "Source code repository"
+      = link_item "announcement", "Announcement"
+      = custom_urls
+
+  %br
+
+  - if m.packages.source
+    %h4 Packages
+    %ul
+      %li
+        = link_to "Source code", m.packages.source
+
+  %p{:class => "edit-link"}
+    = link_to "[Edit]", editor_url
+
+  %br{:clear => "all"}
+
+  - if disqus_enabled?
+    %hr
+
+    #disqus_thread
+
+    :javascript
+      var disqus_config = function () {
+          this.page.url = 'http://inqlude.org/libraries/#{m.name}.html';
+          this.page.identifier = '#{m.name}';
+      };
+      (function() {
+          var d = document, s = d.createElement('script');
+
+          s.src = 'https://inqlude.disqus.com/embed.js';
+
+          s.setAttribute('data-timestamp', +new Date());
+          (d.head || d.body).appendChild(s);
+      })();

--- a/view/two-column/public/inqlude.css
+++ b/view/two-column/public/inqlude.css
@@ -1,5 +1,4 @@
 body {
-  background-color: #eee;
   color: #111;
   margin: 0px;
   font-family: 'Droid Sans', arial, serif;
@@ -22,106 +21,149 @@ a:active {
   text-decoration: underline;
 }
 
-.ribbon {
-  background-color: #a00;
-  overflow: hidden;
-  position: absolute;
-  left: -2em;
-  top: 1em;
-  -moz-transform: rotate(-45deg);
-  -webkit-transform: rotate(-45deg);
-  -moz-box-shadow: 0 0 1em #888;
-  -webkit-box-shadow: 0 0 1em #888;
-}
-.ribbon a {
-  border: 1px solid #faa;
-  color: #fff;
-  display: block;
-  font: bold 81.25% 'Helvetiva Neue', Helvetica, Arial, sans-serif;
-  margin: 0.05em 0 0.075em 0;
-  padding: 0.5em 3.5em;
-  text-align: center;
-  text-decoration: none;
-  text-shadow: 0 0 0.5em #444;
-}
-
 h1 {
-  text-align: center;
   font-family: monospace;
   font-size: 200%;
   font-weight: normal;
-  margin-top: 0px;
   margin-bottom: 0px;
+  padding-top: 5px;
 }
 
 h1 .logo {
-  font-size: 200%;
+  font-size: 180%;
   font-weight: bold;
-  margin: 0px;
 }
 
 h1 .green {
   color: #80C342;
 }
 
-
-h1 .subtitle {
-  padding-left: 12px;
+h2 {
+  margin-top: -5px;
 }
 
-.container {
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 18px;
-  width: 940px;
-  background-color: #f8f8f8;
-  padding: 20px;
-  padding-top: 0px;
-  -webkit-box-shadow: 0px 6px 15px rgba(50, 50, 50, 0.6);
-  -moz-box-shadow:    0px 6px 15px rgba(50, 50, 50, 0.6);
-  box-shadow:         0px 6px 15px rgba(50, 50, 50, 0.6);
+h2 .subtitle {
+  font-weight: bold;  
+  font-size: 78%;
 }
 
-.header {
-  margin-left: -30px;
-  width: 980px;
-  background-color: #fafafa;
-  padding: 10px;
-  -webkit-box-shadow: 0px 6px 20px rgba(50, 50, 50, 0.5);
-  -moz-box-shadow:    0px 6px 20px rgba(50, 50, 50, 0.5);
+h3, h4, h6 {
+  font-weight: bold;  
+}
+
+.container-fluid.header {  
+  -webkit-box-shadow: 0px 6px 0px rgba(50, 50, 50, 0.5);
+  -moz-box-shadow:    0px 6px 0px rgba(50, 50, 50, 0.5);
   box-shadow:         0px 6px 20px rgba(50, 50, 50, 0.5);
+  background-color: #eee;
+  padding-left: 0px;
+  padding-right: 0px;
 }
 
-.logo {
-  float: left;
-  margin: 20px;
-}
-
-.menu {
-  margin-right: 20px;
+.col-md-8.logo {
+  margin-top: -10px;
   padding: 0px;
+  padding-bottom: 5px;
+  padding-left: 10px;
+}
+
+.col-md-4.search {
   text-align: right;
+  padding-top: 50px;
+}
+
+.container-fluid.content {
+  padding-right: 10px;
+  padding-left: 10px;
+}
+
+.col-sm-3.side-bar {
+  padding: 0px;
+}
+
+.col-sm-12.description {
+  text-align: justify;
+  background-color: #eee;
+  margin-top: 10px;
+  margin-bottom: 5px;
+  padding: 5px;
+}
+
+.col-sm-12.title {  
+  background-color: #a4d477;
+  font-weight: bold;
+  padding: 0px;
+  padding-left: 5px;
+}
+
+.col-sm-12.latest-releases {
+  background-color: #eee;
+  margin-bottom: 5px;
+  padding-left: 30px;
+}
+
+.col-sm-12.filters {
+  background-color: #eee;
+  margin-bottom: 5px;
+  padding: 5px;
+}
+
+.col-sm-5.filter-platforms {
+  margin-bottom: 20px;
+}
+
+.col-sm-9.main-pane {  
+  padding-top: 10px;
+  padding-left: 10px;
+  padding-right: 0px;
+}
+
+.col-sm-12.inner-box {
+  text-align: justify;
+  padding: 30px;
+  padding-top: 0px;
+}
+
+date {
   float: right;
 }
 
-.menu ul {
-  list-style-type: none;
+ul {
+  list-style-type: circle;
+  padding-left: 30px;
 }
 
-.search {
-  width: 250px;
+table.table-hover tr:hover td, .table-hover tbody tr:hover th {
+  background-color: #a4d477;
 }
 
-.menu_items {
-  color: white;
+tr:nth-child(even) {
+  background-color: #eee;
 }
 
-.menu_items a {
-  color: white;
+td {
+  vertical-align: top;
+  padding: 5px;
 }
 
-.content {
-  padding-top: 10px;
+td.name {
+  width: 15%;
+}
+
+td.summary {
+  width: 35%;
+}
+
+td.platforms {
+  width: 10%;
+}
+
+td.topics {
+  width: 20%;
+}
+
+td.licenses {
+  width: 20%;
 }
 
 .code {
@@ -146,9 +188,22 @@ h1 .subtitle {
   font-style: italic;
 }
 
-td {
-  vertical-align: top;
-  padding-left: 16px;
+.col-sm-12.topics-bar {
+  padding: 0px;
+}
+
+.labels {
+  background-color: #a4d477;
+  margin-right: 10px;
+  font-size: 13px;
+  float: left;
+  padding: 4px;
+}
+
+home {
+  float: right;
+  font-style: italic;
+  margin-right: 30px;
 }
 
 .footer {

--- a/view/two-column/search.html.haml
+++ b/view/two-column/search.html.haml
@@ -1,0 +1,20 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4 Search results
+
+  %hr
+
+  %gcse:searchresults-only
+    Loading...
+  :javascript
+    (function() {
+      var cx = '012526638842992167133:g7thmrlp2uw';
+      var gcse = document.createElement('script');
+      gcse.type = 'text/javascript';
+      gcse.async = true;
+      gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(gcse, s);
+    })();


### PR DESCRIPTION
* Add a responsive grid layout.

* Change layout to include sidebar.
  The sidebar contains the general description, a box for latest libraries, and a box for filtering by topics, platforms and licenses. Initially, the two last boxes are filled with static data.

* Show topic, license, and platform information in list of libraries.
  Include separate columns for display_name, summary, topics, licenses and platforms in a compact form as icons.

* Add topics of the libraray as labels to the library pages.