### PR TITLE
Initial prototype for the new layout of the website

### DIFF
--- a/lib/manifest_handler.rb
+++ b/lib/manifest_handler.rb
@@ -53,6 +53,30 @@ class ManifestHandler
       manifest.licenses.include? "Commercial"
     end
   end
+
+  def latest_libraries
+    recent_releases = Array.new
+
+    libraries.select do |library|
+      if library.latest_manifest.has_version? && library.latest_manifest.group != "kde-frameworks"
+        recent_releases.push library
+      end
+    end
+
+    recent_releases.sort! {|a,b| a.latest_manifest.release_date <=> b.latest_manifest.release_date}
+    recent_releases.reverse! 
+
+    return recent_releases[0 .. 4]
+  end
+
+  def is_kde_latest?
+    latest_libraries.select do |library|
+      if group("kde-frameworks")[1].latest_manifest.release_date > library.latest_manifest.release_date 
+        return true
+      end
+    end
+    return false
+  end
   
   def group name
     return @libraries.select do |l|

--- a/lib/view.rb
+++ b/lib/view.rb
@@ -112,6 +112,10 @@ class View
     "<a href=\"#{@root}libraries/#{name}.html\">#{name}</a>"
   end
 
+  def link_to_library name, display_name
+    "<a href=\"#{@root}libraries/#{name}.html\">#{display_name}</a>"
+  end
+
   def link url
     "<a href=\"#{url}\" target=\"_blank\">#{url}</a>"
   end
@@ -121,6 +125,10 @@ class View
       url = "#{@root}#{url}.html"
     end
     "<a href=\"#{url}\">#{title}</a>"
+  end
+
+  def link_to_group name, display_name
+    "<a href=\"#{@root}groups/#{name}.html\">#{display_name}</a>"
   end
 
   def list_attribute attribute
@@ -213,6 +221,14 @@ class View
     @manifest_handler.commercial_libraries
   end
 
+  def latest_libraries
+    @manifest_handler.latest_libraries
+  end
+
+  def is_kde_latest?
+    @manifest_handler.is_kde_latest?
+  end
+
   def group_title
     if @group_name == "kde-frameworks"
       return "KDE Frameworks"
@@ -255,6 +271,22 @@ class View
   def render_description
     doc = Kramdown::Document.new(@manifest.description)
     doc.to_html
+  end
+
+  def kde_frameworks_release_date
+    @manifest_handler.group("kde-frameworks")[1].latest_manifest.release_date
+  end
+
+  def topics
+    ['API', 'Artwork', 'Bindings', 'Communication', 'Data', 'Desktop', 'Development', 'Graphics', 'Logging', 'Mobile', 'Multimedia', 'Printing', 'QML', 'Scripting', 'Security', 'Text', 'Web', 'Widgets']
+  end
+
+  def platforms
+    ['Android','iOS','Linux','OS x','Windows']
+  end
+
+  def licenses
+    ['Apache','BSD','Commercial','GPL','LGPL','MIT','Qwt']
   end
 
   private

--- a/spec/unit/manifest_handler_spec.rb
+++ b/spec/unit/manifest_handler_spec.rb
@@ -87,6 +87,12 @@ describe ManifestHandler do
       expect( libraries[1].manifests.last.name ).to eq "commercial"
     end
 
+    it "returns latest libraries" do
+      libraries = mh.latest_libraries
+      expect(libraries.first.manifests.last.name).to eq "proprietarylib" 
+      expect(libraries).not_to include "newlib"
+    end
+
   end
 
   describe "#group" do

--- a/spec/unit/view_spec.rb
+++ b/spec/unit/view_spec.rb
@@ -44,6 +44,15 @@ describe View do
       expect(v.commercial_libraries.count).to eq mh.commercial_libraries.count
       expect(v.commercial_libraries.first.name).to eq mh.commercial_libraries.first.name
     end
+
+    it "returns list of latest libraries" do
+      mh = ManifestHandler.new settings
+      mh.read_remote
+      v = View.new mh
+      
+      expect(v.latest_libraries.count).to eq mh.latest_libraries.count
+      expect(v.latest_libraries.first.name).to eq mh.latest_libraries.first.name
+    end
     
     it "returns group" do
       mh = ManifestHandler.new settings
@@ -53,6 +62,14 @@ describe View do
       
       expect(v.group.count).to eq mh.group("kde-frameworks").count
       expect(v.group.first.name).to eq mh.group("kde-frameworks").first.name
+    end
+
+    it "checks if kde-frameworks are released recently" do
+      mh = ManifestHandler.new settings
+      mh.read_remote
+      v = View.new mh
+      
+      expect(v.is_kde_latest?).to eq mh.is_kde_latest?
     end
   end
   

--- a/view/two-column/about.html.haml
+++ b/view/two-column/about.html.haml
@@ -1,0 +1,37 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4 About Inqlude
+
+  %hr
+
+  %p
+    The goal of Inqlude is to provide a comprehensive listing of all
+    existing libraries for developers of Qt applications. If you are creating
+    applications using the Qt toolkit, and are looking for libraries, components
+    or modules to use, Inqlude is the place where you find all information and
+    pointers to get started.
+  %p
+    Inqlude comes with a command line client for handling libraries. See the
+    = link_to "instructions how to get libraries", "get"
+    for more details.
+  %p
+    Inqlude aims to be a complete archive of all available Qt based
+    libraries. If you notice that there is some information missing, outdated
+    or inaccurate, please consider contributing the missing data. See the
+    = link_to "instructions how to contribute", "contribute"
+    for more details.
+  %p
+    %em
+      Note that Inqlude is currently in alpha state. It's not ready for full
+      production use yet. Data is still incomplete, and the tools are
+      limited. Feedback and input is appreciated.
+  %p
+    If you have questions of comments please feel free to write to the Inqlude
+    mailing list #{link_to "inqlude@kde.org", "mailto:inqlude@kde.org"}.
+  %p
+    Inqlude was created by
+    = link_to "Cornelius Schumacher", "mailto:schumacher@kde.org"
+    with the help of many others, and is a proud  member of the KDE family.
+  %br

--- a/view/two-column/contribute.html.haml
+++ b/view/two-column/contribute.html.haml
@@ -1,0 +1,58 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4 Contributing data about libraries
+
+  %hr
+
+  %p
+    To get a complete overview about all available Qt based libraries, we need
+    to collect data about these libraries. This includes descriptions,
+    instructions how to use them, as well as links to sources or installable
+    packages.
+  %p
+    The meta data used by Inqlude is collected in a git repository at
+    = link( "http://github.com/cornelius/inqlude-data" )
+    or
+    = link( "https://projects.kde.org/projects/websites/inqlude-data" ) + "."
+    It contains a manifest file in JSON format for each library, which has the
+    meta data in a structured machine-readable form. JSON is easy enough for
+    humans to read and edit as well. See the
+    = link_to "specification of the manifest format", "https://github.com/cornelius/inqlude/blob/master/manifest-format.md"
+    for documentation about what to put into the manifest.
+  %p
+    You can contribute meta data by providing patches to the inqlude-data
+    repository. Use the github mechanisms or just send patches by email.
+    Contributions are welcome.
+
+  %br
+
+  %h4 Contributing to the Inqlude tools
+
+  %hr
+
+  %p
+    The command line tool is developed in another git repository at
+    = link( "http://github.com/cornelius/inqlude" )
+    or
+    = link( "https://projects.kde.org/projects/websites/inqlude" ) + "."
+    It's still in a proof-of-concept state, so there is quite a bit work left.
+    Have a look at the
+    = link_to "list of open issues", "http://github.com/cornelius/inqlude/issues"
+    or read the source and come up with your own ideas what to improve.
+  %p
+    Especially welcome are contributions for adding support for native
+    package systems on the variety of Linux distributions and other systems
+    out there.
+    
+  %br
+
+  %h4 Mailing list
+
+  %hr
+
+  %p
+    If you want to discuss any aspects of Inqlude, get in contact with us, have
+    questions, or want to contribute in any other way, the best way is to use the
+    mailing list #{link_to "inqlude@kde.org", "https://mail.kde.org/mailman/listinfo/inqlude"}.

--- a/view/two-column/get.html.haml
+++ b/view/two-column/get.html.haml
@@ -1,0 +1,61 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4
+    How to get libraries
+
+  %hr
+
+  %p
+    This page is about how to use Inqlude as a user, a developer using Qt
+    based libraries in her projects.
+  %p
+    First you can just use the web site. Find the information about libraries
+    here, and get the libraries using the provided links. This works and is the
+    recommended way for now, but there is an experimental, but more convenient
+    way.
+  %p
+    You can also use the command line client. This client makes it easy to get
+    the libraries you need with just a few commands, without having to know
+    URLs, or how libraries are packages.
+  %p
+    First you need to get the command line client.
+    It's a Qt 5 application. If your distribution doesn't have a package for
+    inqlude-client, you can download its sources from
+    = link_to( "download.kde.org", "http://download.kde.org/devel/helpers/")
+    or using
+    .code
+      git clone git://anongit.kde.org/inqlude-client
+  %p
+    There is a second command line client, written in Ruby. It can also
+    download libraries, but it is mostly aimed at maintaining the inqlude data.
+    It's available as a Ruby gem, so when you have rubygems installed you can simply do a
+    .code
+      sudo gem install inqlude
+    (For instructions how to get rubygems, see
+    = link_to( "rubygems.org", "http://rubygems.org" ) + ")."
+  %p
+    Once you have the client, you can get help about the available commands
+    with
+    .code
+      inqlude
+    Get a list of available libraries with
+    .code
+      inqlude list -r
+
+    Install a library with 
+    .code
+      inqlude install &lt;library_name&gt;
+
+    Get a list of installed libraries with
+    .code
+      inqlude list
+  %p
+    The command line client uses your native package management system. In
+    case there is no meta data available for your system, the client falls
+    back to handling sources. Please consider helping to get your system
+    supported by contributing meta data or implementing a backend for your
+    system. See the
+    = link_to "instructions how to contribute", "contribute"
+    for more details.

--- a/view/two-column/group.html.haml
+++ b/view/two-column/group.html.haml
@@ -1,19 +1,45 @@
-%h2
+%link(rel="stylesheet" type="text/css" href="../public/inqlude.css")
+
+%home
+  = link_to "Home", "index"
+
+%h4
   = group_title
 
-%table
+%table.table-hover.col-sm-12
   - group.each do |library|
-    %tr
-      %td.first
-        = link_to_manifest library.name
-      %td.last
-        = library.latest_manifest.summary
-        %span{"class" => "library-short-meta-data"}
-          - if !library.latest_manifest.is_released?
-            (unreleased,
-          - else
-            (#{library.latest_manifest.maturity},
-          #{library.latest_manifest.licenses.join(", ")})
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple
+      %td.topics
+        - if library.manifests.last.topics
+          - library.manifests.last.topics.each do |topic|
+            - if (topic != library.manifests.last.topics.last)
+              = topic + ", "
+            - else 
+              = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+%br
 
 %p
   #{group.count} libraries listed in group #{group_title}.

--- a/view/two-column/home.html.haml
+++ b/view/two-column/home.html.haml
@@ -1,2 +1,0 @@
-%p
-  This is home page.

--- a/view/two-column/index.html.haml
+++ b/view/two-column/index.html.haml
@@ -1,0 +1,182 @@
+%h4
+  Stable libraries
+
+%table.table-hover.col-sm-12
+  - libraries(:stable).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple
+      %td.topics
+        - if library.manifests.last.topics
+          - library.manifests.last.topics.each do |topic|
+            - if (topic != library.manifests.last.topics.last)
+              = topic + ", "
+            - else 
+              = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+%h4
+  Developer releases
+
+%table.table-hover.col-sm-12
+  - libraries(:beta).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple         
+      %td.topics
+        - if library.manifests.last.topics
+          - library.manifests.last.topics.each do |topic|
+            - if (topic != library.manifests.last.topics.last)
+              = topic + ", "
+            - else 
+              = topic                    
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+  - libraries(:alpha).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple         
+      %td.topics
+        - if library.manifests.last.topics
+          - library.manifests.last.topics.each do |topic|
+            - if (topic != library.manifests.last.topics.last)
+              = topic + ", "
+            - else 
+              = topic                     
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+  - libraries(:edge).each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple         
+      %td.topics
+        - if library.manifests.last.topics
+          - library.manifests.last.topics.each do |topic|
+            - if (topic != library.manifests.last.topics.last)
+              = topic + ", "
+            - else 
+              = topic                     
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+%h4
+  Unreleased libraries
+
+%table.table-hover.col-sm-12
+  - unreleased_libraries.each do |library|
+    %tr 
+      %td.name
+        - if library.latest_manifest.display_name
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+        - else
+          = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+      %td.summary
+        = library.manifests.last.summary      
+      %td.platforms
+        %link{:href => "http://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css", :rel => "stylesheet"}
+        - if library.manifests.last.platforms.include? 'Windows'
+          %i.fa.fa-windows
+        - if library.manifests.last.platforms.include? 'Linux' 
+          %i.fa.fa-linux
+        - if library.manifests.last.platforms.include? 'Android'
+          %i.fa.fa-android
+        - if (library.manifests.last.platforms.include? 'iOS') || (library.manifests.last.platforms.include? 'OS X') 
+          %i.fa.fa-apple
+      %td.topics
+        - if library.manifests.last.topics
+          - library.manifests.last.topics.each do |topic|
+            - if (topic != library.manifests.last.topics.last)
+              = topic + ", "
+            - else 
+              = topic                     
+      %td.licenses
+        - library.manifests.last.licenses.each do |license|
+          - if (license != library.manifests.last.licenses.last)
+            = license + ", "
+          - else 
+            = license
+
+%hr
+
+%span.footer
+  Last updated on #{Date.today}
+  

--- a/view/two-column/layout.html.haml
+++ b/view/two-column/layout.html.haml
@@ -5,45 +5,89 @@
   - if enable_search
     <link href='https://fonts.googleapis.com/css?family=Droid+Sans' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="https://www.google.com/cse/style/look/default.css" type="text/css" />
-%body
-  .ribbon
-    = link_to "Alpha", "about"
+  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" type="text/css" href="public/inqlude.css">  
 
-  .container
-    .header
-      .logo
-        %h1
-          %span.logo><
-            \#in
-          %span.logo.green><
-            q
-          %span.logo><
-            lude
-        %h2
-          %span.subtitle
-            The Qt library archive
-      .menu
-        %ul
+%body
+
+  .container-fluid.header
+
+    .col-sm-8.left
+      .ribbon
+        = link_to "Alpha", "about"    
+      %h1
+        %span.logo><
+          \#in
+        %span.logo.green><
+          q
+        %span.logo><
+          lude
+      %h2
+        %span.subtitle
+          The Qt library archive
+
+    .col-sm-4.right  
+      - if enable_search
+        %gcse:searchbox-only{ resultsUrl: "https://inqlude.org/search.html" }
+          Loading...
+    %br{ :clear => "all" }
+
+  .container-fluid.content
+
+    .col-sm-3.side-bar
+
+      .col-sm-12.description
+        %p
+          Inqlude provides a comprehensive listing of all existing libraries for developers of applications using the #{link_to "Qt toolkit", "http://qt-project.org"}. Inqlude is run by the community and open for contributions. 
+      
+        %ul.titles-list
           %li
-            = link_to "Home", "index"
+            = link_to "About", "about"
           %li
             = link_to "How to get libraries", "get"
           %li
-            = link_to "How to contribute", "contribute"
-          %li
-            = link_to "About", "about"
-        .search
-          - if enable_search
-            %gcse:searchbox-only{ resultsUrl: "https://inqlude.org/search.html" }
-              Loading...
-      %br{ :clear => "all" }
+            = link_to "How to contribute", "contribute"          
+          
+      .col-sm-12.latest-releases
+        .col-sm-12.title
+          Latest releases
+        .col-sm-12.latest-releases-content
+          %table
+            %tr
+              %td
+                - latest_libraries.each do |library|
+                  - if library.latest_manifest.display_name
+                    = link_to_library(library.latest_manifest.name, library.latest_manifest.display_name)
+                  - else
+                    = link_to_library(library.latest_manifest.name, library.latest_manifest.name)
+                  %date
+                    = '(' + library.latest_manifest.release_date + ')'
+                  %br
+                - if is_kde_latest?
+                  = link_to_group('kde-frameworks', 'KDE Frameworks')
+                  %date
+                    = '(' + kde_frameworks_release_date + ')'
 
-    .content
+      .col-sm-12.filters
+        .col-sm-12.title
+          Filters
+        .col-sm-12.filters-content
+          %h6
+            Topics
+          %ul.topics-list
+            %li
+              - topics.each do |topic|
+                = topic
+                %br
+
+    .col-sm-9.main-pane 
       = yank
 
       %br{ :clear => "all" }
 
-  .legal
+  %hr
+  
+  .col-sm-12.legal
     Inqlude is a
     = link_to "KDE project", "http://kde.org"
     = "|"

--- a/view/two-column/library.html.haml
+++ b/view/two-column/library.html.haml
@@ -1,54 +1,69 @@
-%h2
-  = m.name
+%link(rel="stylesheet" type="text/css" href="../public/inqlude.css")
 
-%p
-  = m.summary
+%home
+  = link_to "Home", "index"
 
-- if m.has_version?
-  = list_attribute_content "Version", version_content
-= list_attribute "licenses"
-= list_attribute "platforms"
-= list_attribute "authors"
-= list_attribute_content "Home page", link( m.urls.homepage )
-= list_attribute "topics"
-= render_description
+.inner-box.col-sm-12
+  %h4
+    -if m.display_name
+      = m.display_name
+    -else 
+      = m.name
 
-- if more_urls?
-  %h3 Read more
-  %ul
-    = link_item "api_docs", "API documentation"
-    = link_item "tutorial", "Tutorial"
-    = link_item "download", "Download sources"
-    = link_item "vcs", "Source code repository"
-    = link_item "announcement", "Announcement"
-    = custom_urls
-
-- if m.packages.source
-  %h3 Packages
-  %ul
-    %li
-      = link_to "Source code", m.packages.source
-
-%p{:class => "edit-link"}
-  = link_to "[Edit]", editor_url
-
-%br{:clear => "all"}
-
-- if disqus_enabled?
   %hr
 
-  #disqus_thread
+  %p
+    = m.summary
 
-  :javascript
-    var disqus_config = function () {
-        this.page.url = 'http://inqlude.org/libraries/#{m.name}.html';
-        this.page.identifier = '#{m.name}';
-    };
-    (function() {
-        var d = document, s = d.createElement('script');
+  - if m.has_version?
+    = list_attribute_content "Version", version_content
+  = list_attribute "licenses"
+  = list_attribute "platforms"
+  = list_attribute "authors"
+  = list_attribute "topics"
+  = list_attribute_content "Home page", link( m.urls.homepage )
+  = render_description
 
-        s.src = 'https://inqlude.disqus.com/embed.js';
+  %br
 
-        s.setAttribute('data-timestamp', +new Date());
-        (d.head || d.body).appendChild(s);
-    })();
+  - if more_urls?
+    %h4 Read more
+    %ul
+      = link_item "api_docs", "API documentation"
+      = link_item "tutorial", "Tutorial"
+      = link_item "download", "Download sources"
+      = link_item "vcs", "Source code repository"
+      = link_item "announcement", "Announcement"
+      = custom_urls
+
+  %br
+
+  - if m.packages.source
+    %h4 Packages
+    %ul
+      %li
+        = link_to "Source code", m.packages.source
+
+  %p{:class => "edit-link"}
+    = link_to "[Edit]", editor_url
+
+  %br{:clear => "all"}
+
+  - if disqus_enabled?
+    %hr
+
+    #disqus_thread
+
+    :javascript
+      var disqus_config = function () {
+          this.page.url = 'http://inqlude.org/libraries/#{m.name}.html';
+          this.page.identifier = '#{m.name}';
+      };
+      (function() {
+          var d = document, s = d.createElement('script');
+
+          s.src = 'https://inqlude.disqus.com/embed.js';
+
+          s.setAttribute('data-timestamp', +new Date());
+          (d.head || d.body).appendChild(s);
+      })();

--- a/view/two-column/public/inqlude.css
+++ b/view/two-column/public/inqlude.css
@@ -1,5 +1,4 @@
 body {
-  background-color: #eee;
   color: #111;
   margin: 0px;
   font-family: 'Droid Sans', arial, serif;
@@ -46,82 +45,164 @@ a:active {
 }
 
 h1 {
-  text-align: center;
   font-family: monospace;
   font-size: 200%;
   font-weight: normal;
-  margin-top: 0px;
   margin-bottom: 0px;
+  padding-top: 5px;
+  margin-left: 40px;
 }
 
 h1 .logo {
-  font-size: 200%;
+  font-size: 180%;
   font-weight: bold;
-  margin: 0px;
 }
 
 h1 .green {
   color: #80C342;
 }
 
-
-h1 .subtitle {
-  padding-left: 12px;
+h2 {
+  margin-top: -5px;
+  margin-left: 40px;
 }
 
-.container {
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 18px;
-  width: 940px;
-  background-color: #f8f8f8;
-  padding: 20px;
-  padding-top: 0px;
-  -webkit-box-shadow: 0px 6px 15px rgba(50, 50, 50, 0.6);
-  -moz-box-shadow:    0px 6px 15px rgba(50, 50, 50, 0.6);
-  box-shadow:         0px 6px 15px rgba(50, 50, 50, 0.6);
+h2 .subtitle {
+  font-weight: bold;  
+  font-size: 78%;
 }
 
-.header {
-  margin-left: -30px;
-  width: 980px;
-  background-color: #fafafa;
-  padding: 10px;
-  -webkit-box-shadow: 0px 6px 20px rgba(50, 50, 50, 0.5);
-  -moz-box-shadow:    0px 6px 20px rgba(50, 50, 50, 0.5);
+h3, h4, h6 {
+  font-weight: bold;  
+}
+
+.container-fluid.header {  
+  -webkit-box-shadow: 0px 6px 0px rgba(50, 50, 50, 0.5);
+  -moz-box-shadow:    0px 6px 0px rgba(50, 50, 50, 0.5);
   box-shadow:         0px 6px 20px rgba(50, 50, 50, 0.5);
+  background-color: #eee;
+  padding-left: 0px;
+  padding-right: 0px;
 }
 
-.logo {
-  float: left;
-  margin: 20px;
-}
-
-.menu {
-  margin-right: 20px;
+.col-sm-8.left {
+  margin-top: -10px;
   padding: 0px;
+  padding-bottom: 5px;
+  padding-left: 10px;
+}
+
+.col-sm-4.right {
   text-align: right;
-  float: right;
+  padding-top: 50px;
 }
 
-.menu ul {
-  list-style-type: none;
+.container-fluid.content {
+  padding-right: 10px;
+  padding-left: 10px;
 }
 
-.search {
-  width: 250px;
+.col-sm-3.side-bar {
+  padding: 0px;
 }
 
-.menu_items {
-  color: white;
+.col-sm-12.description {
+  text-align: justify;
+  background-color: #eee;
+  margin-top: 10px;
+  margin-bottom: 5px;
+  padding: 5px;
 }
 
-.menu_items a {
-  color: white;
+.col-sm-12.title {  
+  background-color: #a4d477;
+  font-weight: bold;
+  padding: 0px;
+  padding-left: 5px;
 }
 
-.content {
+.col-sm-12.latest-releases {
+  background-color: #eee;
+  margin-bottom: 5px;
+  padding: 0px;
+}
+
+.col-sm-12.latest-releases-content {
+  padding-left: 30px;
+}
+
+.col-sm-12.filters {
+  background-color: #eee;
+  margin-bottom: 5px;
+  padding: 0px;
+}
+
+.col-sm-12.filters-content{
+  padding-left: 30px;
+}
+
+.col-sm-9.main-pane {  
   padding-top: 10px;
+  padding-left: 10px;
+  padding-right: 0px;
+}
+
+.inner-box.col-sm-12 {
+  text-align: justify;
+  padding: 30px;
+  padding-top: 0px;
+}
+
+date {
+  float: right;
+  margin-left: 20px;
+}
+
+ul.titles-list {
+  list-style-type: circle;
+  padding-left: 30px;
+}
+
+ul.topics-list {
+  list-style-type: none;
+  padding-left: 0px;
+}
+
+table.table-hover.col-sm-12 {
+  margin-bottom: 20px;
+}
+
+table.table-hover.col-sm-12 tr:hover td {
+  background-color: #a4d477;
+}
+
+tr:nth-child(even) {
+  background-color: #eee;
+}
+
+td {
+  vertical-align: top;
+  padding: 5px;
+}
+
+td.name {
+  width: 15%;
+}
+
+td.summary {
+  width: 35%;
+}
+
+td.platforms {
+  width: 10%;
+}
+
+td.topics {
+  width: 20%;
+}
+
+td.licenses {
+  width: 20%;
 }
 
 .code {
@@ -146,9 +227,10 @@ h1 .subtitle {
   font-style: italic;
 }
 
-td {
-  vertical-align: top;
-  padding-left: 16px;
+home {
+  float: right;
+  font-style: italic;
+  margin-right: 30px;
 }
 
 .footer {
@@ -162,10 +244,10 @@ td {
   font-size: 80%;
 }
 
-.legal {
-  margin: 12px;
+.col-sm-12.legal {
   text-align: center;
-  font-size: 70%;
+  font-size: 90%;
+  margin-bottom: 15px;
 }
 
 .attribute {
@@ -179,6 +261,7 @@ td {
   text-align: right;
   float: left;
   margin-right: 8px;
+  font-size: 80%;
 }
 
 .attribute .value {

--- a/view/two-column/search.html.haml
+++ b/view/two-column/search.html.haml
@@ -1,0 +1,20 @@
+%home
+  = link_to "Home", "index"
+
+.col-sm-12.inner-box
+  %h4 Search results
+
+  %hr
+
+  %gcse:searchresults-only
+    Loading...
+  :javascript
+    (function() {
+      var cx = '012526638842992167133:g7thmrlp2uw';
+      var gcse = document.createElement('script');
+      gcse.type = 'text/javascript';
+      gcse.async = true;
+      gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(gcse, s);
+    })();


### PR DESCRIPTION
* Add a responsive grid layout.

* Change layout to include sidebar.
  The sidebar contains a box for the general description, a box for latest libraries and a box containing the list of topics.

* Add the five latest libraries to the side bar(This excludes KDE Frameworks). Check if KDE Frameworks belong to latest releases and add it to the side bar accordingly.
  This prevents the display of whole set of libraries under KDE Frameworks once updated. Then the set of libraries is displayed as 'KDE Frameworks'.

* Show topic, license, and platform information in list of libraries.
  Include separate columns for display_name, summary, topics, licenses and platforms in a compact form as icons.

Supersedes: #57, #59