### PR TITLE
Better error when templates directory does not exist

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -98,15 +98,24 @@ actual domain."
 
     manifest_handler = ManifestHandler.new(@@settings)
 
-    puts "Creating web site in '#{output_dir}' from '#{manifest_handler.settings.manifest_path}'"
-
     manifest_handler.read_remote
 
     view = View.new(manifest_handler)
-    view.enable_disqus = options[:enable_disqus]
-    view.enable_search = !options[:disable_search]
+    
     view.templates = options[:templates]
-    view.create output_dir
+
+    if !view.template_directory_exists?
+      STDERR.puts "Error: Templates directory doesn't exist"
+      exit 1
+    else
+      puts "Creating web site in '#{output_dir}' from '#{manifest_handler.settings.manifest_path}'"
+
+      view.enable_disqus = options[:enable_disqus]
+      view.enable_search = !options[:disable_search]
+
+      view.create output_dir
+    end
+
   end
 
   desc "show <library_name>", "Show library details"

--- a/lib/view.rb
+++ b/lib/view.rb
@@ -75,6 +75,10 @@ class View
     end
   end
 
+  def template_directory_exists?
+    File.directory?(view_dir) ? true : false
+  end
+
   def render_template name, output_dir, file_name = nil
     layout = template "layout"
     layout_engine = Haml::Engine.new layout

--- a/spec/integration/cli_view_spec.rb
+++ b/spec/integration/cli_view_spec.rb
@@ -25,6 +25,26 @@ describe "Command line interface" do
       expect(File.exist?(File.join(output_dir, "libraries", "newlib.html"))).to be(true)
     end
 
+    it "checks templates direstory" do
+      dir = given_directory do
+        given_directory_from_data("awesomelib", from: "manifests/awesomelib")
+        given_directory_from_data("newlib", from: "manifests/newlib")
+      end
+
+      output_dir = given_directory
+
+      result = run_command(args: ["view", "--offline", "--manifest_dir=#{dir}",
+        "--output-dir=#{output_dir}", "--templates=one-column"])
+      expect(result).to exit_with_success(/Creating web site/)
+
+      result = run_command(args: ["view", "--offline", "--manifest_dir=#{dir}",
+        "--output-dir=#{output_dir}", "--templates=three-column"])
+      expected_output = <<EOT
+Error: Templates directory doesn't exist
+EOT
+      expect(result).to exit_with_error(1, expected_output)
+    end
+
     it "generates templates" do
       dir = given_directory do
         given_directory_from_data("awesomelib", from: "manifests/awesomelib")


### PR DESCRIPTION
Show an error message when calling `inqlude view` with a `--templates` parameter with a non-existing directory and avoid generating the views.

Resolves: #58