### PR TITLE
Refactor and update markup, fix ios icon

### DIFF
--- a/view/two-column/all.html.haml
+++ b/view/two-column/all.html.haml
@@ -23,7 +23,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "ios.ico", :height => "15%;"}
+          %span.ios
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|

--- a/view/two-column/group.html.haml
+++ b/view/two-column/group.html.haml
@@ -25,7 +25,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "apple.ico", :height => "15%;"}
+          %span.ios
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|

--- a/view/two-column/index.html.haml
+++ b/view/two-column/index.html.haml
@@ -21,7 +21,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "ios.ico", :height => "15%;"}
+          %span.ios
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|
@@ -59,7 +59,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "ios.ico", :height => "15%;"}        
+          %span.ios        
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|
@@ -93,7 +93,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "ios.ico", :height => "15%;"}       
+          %span.ios       
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|
@@ -127,7 +127,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "ios.ico", :height => "15%;"}         
+          %span.ios        
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|
@@ -165,7 +165,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "ios.ico", :height => "15%;"}
+          %span.ios
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|

--- a/view/two-column/layout.html.haml
+++ b/view/two-column/layout.html.haml
@@ -1,27 +1,18 @@
 !!!
 %head
   %meta{ :charset => 'utf-8' }
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-    = style_sheet
+
+  %title Inqlude - The Qt library archive
+
+  %link{ :rel => "stylesheet", :href => "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" }
+  %link{ :rel => "stylesheet", :href => "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" }  
+  = style_sheet
   - if enable_search
-    <link href='https://fonts.googleapis.com/css?family=Droid+Sans' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="https://www.google.com/cse/style/look/default.css" type="text/css" />
-  <!-- Piwik -->
-  :javascript
-    var _paq = _paq || [];
-    // tracker methods like "setCustomDimension" should be called before "trackPageView"
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="//stats.kde.org/";
-      _paq.push(['setTrackerUrl', u+'piwik.php']);
-      _paq.push(['setSiteId', '4']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-    })();
-  <!-- End Piwik Code -->
+    %link{ :rel => "stylesheet", :href => "https://fonts.googleapis.com/css?family=Droid+Sans" }
+    %link{ :rel => "stylesheet", :href => "https://www.google.com/cse/style/look/default.css" }
+
+    %link{ :rel => "icon", :type => "image/x-icon", :href => "favicon.ico" }
+
 %body
   .container-fluid.header
     .col-sm-8.left
@@ -106,3 +97,20 @@
           var s = document.getElementsByTagName('script')[0];
           s.parentNode.insertBefore(gcse, s);
         })();
+  
+  %script{ :src => "https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js" }
+
+  <!-- Piwik -->
+  :javascript
+    var _paq = _paq || [];
+    // tracker methods like "setCustomDimension" should be called before "trackPageView"
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//stats.kde.org/";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', '4']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+  <!-- End Piwik Code -->

--- a/view/two-column/public/inqlude.css
+++ b/view/two-column/public/inqlude.css
@@ -260,3 +260,9 @@ i.fa {
 hr {
   margin-top: 0px;
 }
+
+.ios {
+  background: url("../ios.ico") no-repeat scroll right center rgba(0, 0, 0, 0);
+  padding-left: 20px;
+  background-size: 15px 15px;
+}

--- a/view/two-column/topic.html.haml
+++ b/view/two-column/topic.html.haml
@@ -24,7 +24,7 @@
         - if library.manifests.last.platforms.include? 'Android'
           %i.fa.fa-android
         - if library.manifests.last.platforms.include? 'iOS'
-          %img{:src => "../ios.ico", :height => "15%;"}
+          %span.ios
       %td.topics
         - if library.manifests.last.topics
           - library.manifests.last.topics.each do |topic|


### PR DESCRIPTION
- Update Font Awesome to version 4.7.0
- Reorganize layout template and convert the html markup to haml
- Add title tag
- Include link to favicon in markup
- Move js to the end of the body tag instead of in head
- Fix iOS icon sizing and position